### PR TITLE
Navigation section is added to the main README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,8 @@
 # Материалы для видео с канала [Мир IT c Антоном Павленко](https://www.youtube.com/c/pavlenkoat/)
+
+## Навигация
+
+Имя каждого подкаталога — это идентификатор видео на YouTube: `https://www.youtube.com/watch?v=<video id>`.
+
+* [Web-сервер для ленивых](https://youtu.be/mKdwkV5p1xg), см. [mKdwkV5p1xg](./mKdwkV5p1xg/README.md).
+* [HTTPS для ленивых](https://youtu.be/OgCXa7e-mO0), см. [OgCXa7e-mO0](./OgCXa7e-mO0/README.md).


### PR DESCRIPTION
Было бы удобно, если бы в главном [README.md](./README.md) было видно, какие ролики скрываются за идентификаторами, используемыми в именах подкаталогов, чтобы можно было быстро найти интересующее видео без необходимости заходить в каждую папку.

Предложен вариант реализации.